### PR TITLE
make diff more reabable in YAML output

### DIFF
--- a/create_changelog
+++ b/create_changelog
@@ -35,7 +35,10 @@ diff_to_yaml()
     if [[ ${line/#-/} = $line && ${line/#+/} = $line ]]; then
       echo "  ${line}: |-"
     else
-      echo "    $line"
+      # supress deletions (should not really exist)
+      if [[ ${line:0:1} != "-" ]] ; then
+        echo "    ${line:1}"
+      fi
     fi
   done
 }


### PR DESCRIPTION
Remove leading plus signs to make diff more reabable.
Remove diff deletions entirely to avoid confusion (there shouldn't be any anyway).