### PR TITLE
fix glob for old obsgendiff file name expansion

### DIFF
--- a/create_changelog
+++ b/create_changelog
@@ -209,7 +209,7 @@ for report in /.build.packages/OTHER/*.report \
     echo "==========" >> $changelog
     echo "" >> $changelog
     echo "references:" >> $changelog_yaml
-    sed -n -r -e 's/(.*)(CVE-[[:digit:]]{4}-[[:digit:]]{4})(.*)/\2/p' $changelog | \
+    grep -E -v '^-' $changelog | sed -n -r -e 's/(.*)(CVE-[[:digit:]]{4}-[[:digit:]]{4}[[:digit:]]*)(.*)/\3/pg' | \
     sort -u | sed -e 's/^/ - /' | tee -a $changelog | sed -e 's/^/ /' >> $changelog_yaml
   fi
 

--- a/create_changelog
+++ b/create_changelog
@@ -28,6 +28,7 @@ out=/.build.packages/obsgendiff
 released=/.build.packages/obsgendiff.released
 
 eol=$'\n'
+shopt -s extglob
 
 diff_to_yaml()
 {
@@ -93,7 +94,7 @@ for report in /.build.packages/OTHER/*.report \
   oldobsgendiff="${oldobsgendiff##* }"
   if [ ! -e "$oldobsgendiff" ]; then
     # try to guess where the version is in the string, no guarantee
-    oldobsgendiff=`echo $oldobsgendiff | sed 's,-[0123456789.]*-,-[0123456789\.]*-,'`
+    oldobsgendiff=`echo $oldobsgendiff | sed 's,-[0123456789.]*-,-*([0123456789.])-,'`
     oldobsgendiff=`echo $oldobsgendiff`
     oldobsgendiff="${oldobsgendiff##* }"
   fi


### PR DESCRIPTION
When guessing the file name of the old obsgendiff, `[0123456789\.]*` is used as version string expansion but that will match anything as long as it starts with a digit or a dot. This PR changes the glob to only match strings composed of digits and dots.