### PR TITLE
fix CVE regex

### DIFF
--- a/create_changelog
+++ b/create_changelog
@@ -210,7 +210,7 @@ for report in /.build.packages/OTHER/*.report \
     echo "==========" >> $changelog
     echo "" >> $changelog
     echo "references:" >> $changelog_yaml
-    grep -E -v '^-' $changelog | sed -n -r -e 's/(.*)(CVE-[[:digit:]]{4}-[[:digit:]]{4}[[:digit:]]*)(.*)/\3/pg' | \
+    grep -E -v '^-' $changelog | sed -n -r -e 's/(.*)(CVE-[[:digit:]]{4}-[[:digit:]]{4}[[:digit:]]*)(.*)/\2/pg' | \
     sort -u | sed -e 's/^/ - /' | tee -a $changelog | sed -e 's/^/ /' >> $changelog_yaml
   fi
 


### PR DESCRIPTION
Use the correct match number (2 not 3). Sorry, this might have been a vim accident.