### PR TITLE
better obsgendiff version string guess

### DIFF
--- a/create_changelog
+++ b/create_changelog
@@ -95,7 +95,7 @@ for report in /.build.packages/OTHER/*.report \
   oldobsgendiff="${oldobsgendiff##* }"
   if [ ! -e "$oldobsgendiff" ]; then
     # try to guess where the version is in the string, no guarantee
-    oldobsgendiff=`echo $oldobsgendiff | sed 's,-[0123456789.]*-,-*([0123456789.])-,'`
+    oldobsgendiff=`echo $oldobsgendiff | sed -r -e 's,-[0123456789]+(\.[0123456789]+)+-,-*([0123456789.])-,'`
     oldobsgendiff=`echo $oldobsgendiff`
     oldobsgendiff="${oldobsgendiff##* }"
   fi


### PR DESCRIPTION
Change version string guess to require the version string to be at least two numbers and one digit following a dash, instead of just a simple number.