### PR TITLE
Packaging fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+PREFIX?=/usr
+DESTDIR=
+HOOKDIR=$(DESTDIR)$(PREFIX)/lib/build/obsgendiff.d
+
+install:
+	mkdir -p $(HOOKDIR)
+	install -m 755 create_changelog $(HOOKDIR)
+	cp -r release_compare $(HOOKDIR)

--- a/create_changelog
+++ b/create_changelog
@@ -18,6 +18,10 @@
 # Suite 330, Boston, MA  02111-1307, USA
 
 import argparse
+import os
+import sys
+sys.path.insert(0, os.path.dirname(__file__))
+
 import release_compare
 from release_compare.version import __version__
 

--- a/release-compare.spec
+++ b/release-compare.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package release-compare
 #
-# Copyright (c) 2020 SUSE LLC
+# Copyright (c) 2023 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -15,7 +15,7 @@
 # Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
-%{?!python_module:%define python_module() python-%{**} python3-%{**}}
+%{?!python_module:%define python_module() python3-%{**}}
 %define skip_python2 1
 Name:           release-compare
 Summary:        Release Compare Script
@@ -27,11 +27,14 @@ Release:        0
 Source:         %name-%version.tar.xz
 BuildArch:      noarch
 Requires:       python3-PyYAML
-BuildRequires:  fdupes
-BuildRequires:  python-rpm-macros
 BuildRequires:  %{python_module setuptools}
 BuildRequires:  %{python_module pytest}
 BuildRequires:  %{python_module PyYAML}
+BuildRequires:  fdupes
+BuildRequires:  python-rpm-macros
+Requires:       python3-release-compare
+
+%python_subpackages
 
 %description
 This package contains scripts to create changelog files relative
@@ -39,7 +42,6 @@ to last released result.
 
 Note: you need to use a releasetarget definition in your OBS repository
       to get this working. And the release target needs to have published binaries.
-
 
 %prep
 %setup -q
@@ -56,11 +58,13 @@ install -m 0755 create_changelog $RPM_BUILD_ROOT/usr/lib/build/obsgendiff.d/crea
 %check
 %pytest
 
-%files
+%files -n release-compare
 %license LICENSE
 %doc README.rst
+/usr/lib/build
+
+%files %{python_files}
 %{python_sitelib}/release_compare
 %{python_sitelib}/release_compare-%{version}*-info
-/usr/lib/build
 
 %changelog

--- a/release-compare.spec
+++ b/release-compare.spec
@@ -15,8 +15,6 @@
 # Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
-%{?!python_module:%define python_module() python3-%{**}}
-%define skip_python2 1
 Name:           release-compare
 Summary:        Release Compare Script
 License:        GPL-3.0-or-later
@@ -27,14 +25,9 @@ Release:        0
 Source:         %name-%version.tar.xz
 BuildArch:      noarch
 Requires:       python3-PyYAML
-BuildRequires:  %{python_module setuptools}
-BuildRequires:  %{python_module pytest}
-BuildRequires:  %{python_module PyYAML}
-BuildRequires:  fdupes
-BuildRequires:  python-rpm-macros
-Requires:       python3-release-compare
-
-%python_subpackages
+BuildRequires:  python3-setuptools
+BuildRequires:  python3-pytest
+BuildRequires:  python3-PyYAML
 
 %description
 This package contains scripts to create changelog files relative
@@ -47,24 +40,16 @@ Note: you need to use a releasetarget definition in your OBS repository
 %setup -q
 
 %build
-%python_build
 
 %install
-%python_install
-%python_expand %fdupes %{buildroot}%{$python_sitelib}
-mkdir -p $RPM_BUILD_ROOT/usr/lib/build/obsgendiff.d $RPM_BUILD_ROOT/%_defaultdocdir/%name
-install -m 0755 create_changelog $RPM_BUILD_ROOT/usr/lib/build/obsgendiff.d/create_changelog
+make DESTDIR=%{buildroot} PREFIX=%{_prefix}
 
 %check
-%pytest
+pytest
 
-%files -n release-compare
+%files
 %license LICENSE
 %doc README.rst
 /usr/lib/build
-
-%files %{python_files}
-%{python_sitelib}/release_compare
-%{python_sitelib}/release_compare-%{version}*-info
 
 %changelog

--- a/release_compare/__init__.py
+++ b/release_compare/__init__.py
@@ -28,7 +28,7 @@ import textwrap
 import traceback
 import yaml
 import xml.etree.ElementTree as ET
-from packaging import version as pkg_version
+from setuptools._vendor.packaging import version as pkg_version
 from urllib.parse import urlparse
 from release_compare.version import __log_version__
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ config = {
     'version': __version__,
     'license' : 'GPLv3+',
     'install_requires': [
-        'docopt',
         'PyYAML'
     ],
     'packages': ['release_compare'],


### PR DESCRIPTION
This PR changes the spec file to produce python version specific sub packages and a common package that provides the obsgendiff entry script. This is required to build multi-version packages (e.g. in Tumbleweed). Also uses the packaging module vendored in setuptools instead of the standalone version, removing the dependency on `packaging`, and removes the unused `docopt` module from `setup.py`.